### PR TITLE
Allow module description to be shown as tooltip

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,14 +1,19 @@
 Version Information
 ===================
 
+Version 4.0.0.4
+-----------------------------
+  1. Added ability to display activity description as tooltip (using BS tooltips) (Sebsoft)
+  2. Notice: a known issue arises when the tooltip behaviour is active AND the "old" modpix/modtxt method is used.
+
 Version 4.0.0.3
 -----------------------------
   1. Replace Moodle standard Activity icons with images on activity, course, category or systemlevel (Sebsoft)
-  
+
 Version 4.0.0.2
 -----------------------------
   1. Activity navigation.
-  2. Supports 4.1 
+  2. Supports 4.1
 
 Version 4.0.0.1
 -----------------------------

--- a/classes/course_renderer.php
+++ b/classes/course_renderer.php
@@ -611,8 +611,8 @@ class format_vsf_course_renderer extends \core_course_renderer {
             // Not enabled.
             return $output;
         }
-        if ($mod->showdescription == 1) {
-            // Setting 1 means no.
+        if ($mod->showdescription == 0) {
+            // Setting 0 means no.
             return $output;
         }
         return $mod->get_formatted_content(array('overflowdiv' => true, 'noclean' => true));

--- a/classes/course_renderer.php
+++ b/classes/course_renderer.php
@@ -151,7 +151,7 @@ class format_vsf_course_renderer extends \core_course_renderer {
         $inpaymentlinktag = false;
         $currenttag = '';
         $lasttag = '';
-        $processed = array('text'  => '', 'button' => '');
+        $processed = array('text' => '', 'button' => '');
         $avilen = core_text::strlen($availabilityinfo);
 
         for ($charno = 0; $charno < $avilen; $charno++) {
@@ -604,7 +604,7 @@ class format_vsf_course_renderer extends \core_course_renderer {
     protected function get_tooltip_content(cm_info $mod) {
         $output = '';
         if (!$mod->is_visible_on_course_page()) {
-            // Nothing to be displayed to the user
+            // Nothing to be displayed to the user.
             return $output;
         }
         if (!$this->moduledescriptiontooltip) {

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -565,7 +565,8 @@ class renderer extends section_renderer {
         $headerclasses = 'section-title';
         if ($hasnamenotsecpg || $hasnamesecpg) {
             $activitysummary = $this->section_activity_summary($section, $this->course, null);
-            $barchart = ((!empty($activitysummary)) && (!$this->editing) && ($this->course->chart == 2)); // Chart '2' is 'Bar chart'.
+             // Chart '2' is 'Bar chart'.
+            $barchart = ((!empty($activitysummary)) && (!$this->editing) && ($this->course->chart == 2));
 
             $displaysectioncontext['header'] = $this->section_header_helper(
                     $this->section_title_without_link($section, $this->course),

--- a/lang/en/format_vsf.php
+++ b/lang/en/format_vsf.php
@@ -188,3 +188,9 @@ $string['modicons:cm:changes:saved'] = 'Course module icon override saved';
 $string['modicons:global'] = 'Global custom module icons (system level)';
 $string['modicons:course'] = 'Course custom module icon (course category level)';
 $string['modicons:coursecat'] = 'Coursecategory custom module icons (course category level)';
+// Module description tooltip.
+$string['moduledescriptiontooltip'] = 'Module description tooltip';
+$string['moduledescriptiontooltip_help'] = 'State if the module description will be visible as a tooltip when hovering over the activity icon/button.';
+$string['defaultmoduledescriptiontooltip'] = 'Module description tooltip default';
+$string['defaultmoduledescriptiontooltip_desc'] = 'Default setting to state if the module description will be visible as a tooltip when hovering over the activity icon/button.';
+

--- a/lang/nl/format_vsf.php
+++ b/lang/nl/format_vsf.php
@@ -147,3 +147,10 @@ $string['modicons:cm:changes:saved'] = 'Cursusactiviteitsafbeelding voor activit
 $string['modicons:global'] = 'Globale custom afbeeldingen (systeemniveau)';
 $string['modicons:course'] = 'Cursus custom afbeeldingen (cursusniveau)';
 $string['modicons:coursecat'] = 'Cursuscategorie custom afbeeldingen (cursuscategorieniveau)';
+
+// Module description tooltip.
+$string['moduledescriptiontooltip'] = 'Module beschrijving tonen als tooltip';
+$string['moduledescriptiontooltip_help'] = 'De beschrijving van een activiteit wordt als tooltip/confirm box getoond wanneer er overheen wordt bewogen met de muis/op wordt geklikt.';
+$string['defaultmoduledescriptiontooltip'] = 'Standaard beschrijving tonen als tooltip';
+$string['defaultmoduledescriptiontooltip_desc'] = 'Standaardinstelling voor het tonen van de beschrijving van een activiteit wanneer er met de muis overheen wordt bewogen/op wordt geklikt.';
+

--- a/lib.php
+++ b/lib.php
@@ -262,6 +262,10 @@ class format_vsf extends core_courseformat\base {
                     'default' => get_config('format_vsf', 'defaultmoduleviewbutton'),
                     'type' => PARAM_INT
                 ),
+                'moduledescriptiontooltip' => array(
+                    'default' => get_config('format_vsf', 'defaultmoduledescriptiontooltip'),
+                    'type' => PARAM_INT
+                ),
                 // Continue button.
                 'continuebackgroundcolour' => array(
                     'default' => $defaults['defaultcontinuebackgroundcolour'],
@@ -351,6 +355,18 @@ class format_vsf extends core_courseformat\base {
                         )
                     ),
                     'help' => 'moduleviewbutton',
+                    'help_component' => 'format_vsf',
+                ),
+                'moduledescriptiontooltip' => array(
+                    'label' => new lang_string('moduledescriptiontooltip', 'format_vsf'),
+                    'element_type' => 'select',
+                    'element_attributes' => array(
+                        array(
+                            1 => new lang_string('no'),
+                            2 => new lang_string('yes')
+                        )
+                    ),
+                    'help' => 'moduledescriptiontooltip',
                     'help_component' => 'format_vsf',
                 ),
                 // Continue button.

--- a/settings.php
+++ b/settings.php
@@ -66,6 +66,18 @@ if ($ADMIN->fulltree) {
     );
     $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
 
+    // Module view button.
+    // 1 = no, 2 = yes.
+    $name = 'format_vsf/defaultmoduledescriptiontooltip';
+    $title = get_string('defaultmoduledescriptiontooltip', 'format_vsf');
+    $description = get_string('defaultmoduledescriptiontooltip_desc', 'format_vsf');
+    $default = 2;
+    $choices = array(
+        1 => new lang_string('no'),   // No.
+        2 => new lang_string('yes')   // Yes.
+    );
+    $settings->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
+
     // Default continue button background colour in hexadecimal RGB with preceding '#'.
     $name = 'format_vsf/defaultcontinuebackgroundcolour';
     $title = get_string('defaultcontinuebackgroundcolour', 'format_vsf');

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -34,4 +34,7 @@
 require(['core_courseformat/local/content'], function(component) {
     component.init('{{uniqid}}-course-format', {}, {{sectionreturn}});
 });
+require(['jquery'], function($) {
+    $('[data-vsf-tooltip="1"]').tooltip({html:true});
+});
 {{/js}}

--- a/version.php
+++ b/version.php
@@ -27,9 +27,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023021301;
+$plugin->version   = 2023021302;
 $plugin->maturity = MATURITY_BETA;
 $plugin->requires = 2022041900.00; // This is Moodle 4.0 (Build: 20220419).
 $plugin->supported = array(400, 401);
 $plugin->component = 'format_vsf';
-$plugin->release = '4.0.0.3';
+$plugin->release = '4.0.0.4';

--- a/version.php
+++ b/version.php
@@ -27,9 +27,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021120701;
+$plugin->version = 2021120701;
 $plugin->maturity = MATURITY_BETA;
-$plugin->requires  = 2022041900.00; // This is Moodle 4.0 (Build: 20220419).
+$plugin->requires = 2022041900.00; // This is Moodle 4.0 (Build: 20220419).
 $plugin->supported = array(400, 401);
 $plugin->component = 'format_vsf';
 $plugin->release = '4.0.0.2';


### PR DESCRIPTION
Allow module description to be shown as tooltip.

Added:
- language(s)
- default settings
- module specific settings
- functionality in course_renderer
- JS tooptip call in mustache template (content.mustache, seerms the only and logic place here)